### PR TITLE
DX: colorize `sphinx-build` output

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -41,6 +41,8 @@ commands =
 description =
   Build documentation and API through Sphinx
 passenv = *
+setenv =
+  FORCE_COLOR = yes
 
 [testenv:doclive]
 allowlist_externals =
@@ -57,6 +59,8 @@ commands =
 description =
   Set up a server to preview changes to the HTML pages live
 passenv = *
+setenv =
+  FORCE_COLOR = yes
 
 [testenv:docnb]
 allowlist_externals =
@@ -68,6 +72,7 @@ description =
 passenv = *
 setenv =
   EXECUTE_NB = yes
+  FORCE_COLOR = yes
 
 [testenv:linkcheck]
 allowlist_externals =
@@ -81,6 +86,8 @@ commands =
 description =
   Check external links in the documentation (requires internet connection)
 passenv = *
+setenv =
+  FORCE_COLOR = yes
 
 [testenv:sty]
 allowlist_externals =


### PR DESCRIPTION
- Closes https://github.com/ComPWA/repo-maintenance/issues/108
- Sets `passenv = *` to make the config DRY